### PR TITLE
**FINAL-REMINDER****IMPORTANT** **ACTION REQUIRED** Migration of GHA SelfHosted Runners

### DIFF
--- a/.github/workflows/deploy-to-lambda-signed.yaml
+++ b/.github/workflows/deploy-to-lambda-signed.yaml
@@ -148,8 +148,7 @@ jobs:
     if: ${{ success() || failure() }} # ensures this job runs even on failure
     needs: [deploy-lambda]
     runs-on:
-      - self-hosted
-      - platform-eng-ent
+      - platform-eng-ent-v2-dual
     steps:
       - name: Register deployment
         uses: SPHTech-Platform/deploy-actions/register_deploy_dx@v2


### PR DESCRIPTION
**Automated PR**: Migrating GitHub Actions Runners to a consolidated cluster. This PR updates runner labels.  Test your pipelines before the merge deadline: February 20, 2025. Pipelines using old labels will break after they are removed.